### PR TITLE
Return None if file is not selected

### DIFF
--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -412,10 +412,13 @@ class FileChooser(VBox):
     @property
     def selected(self):
         """Get selected value."""
-        return os.path.join(
-            self._selected_path,
-            self._selected_filename
-        )
+        try:
+            return os.path.join(
+                self._selected_path,
+                self._selected_filename
+            )
+        except TypeError:
+            return None
 
     @property
     def selected_path(self):


### PR DESCRIPTION
Currently

`filename = fc.selected` will throw a `TypeError` if no file has been selected.
This commit modifies `.selected` to return `None` if no file was previously selected.

This is consisted with the behaviour of `.selected_path` and `.selected_filename`