### PR TITLE
Optionally use icons to distinguish directories from files

### DIFF
--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -97,7 +97,7 @@ class FileChooser(VBox):
                 'black'
             ),
             placeholder='',
-            description='',
+            description=''
         )
 
         # Layout
@@ -113,10 +113,10 @@ class FileChooser(VBox):
                 grid_gap='0px 0px',
                 grid_template_rows='auto auto',
                 grid_template_columns='60% 40%',
-                grid_template_areas="""
+                grid_template_areas='''
                     'pathlist filename'
                     'dircontent dircontent'
-                    """
+                    '''
             )
         )
         buttonbar = HBox(
@@ -125,7 +125,7 @@ class FileChooser(VBox):
                 self._cancel,
                 self._label
             ],
-            layout=Layout(width='auto'),
+            layout=Layout(width='auto')
         )
 
         # Call setter to set initial form values
@@ -188,8 +188,7 @@ class FileChooser(VBox):
         # If the value in the filename Text box equals a value in the
         # Select box and the entry is a file then select the entry.
         if ((filename in dircontent_real_names) and
-                os.path.isfile(os.path.join(path, filename))
-        ):
+                os.path.isfile(os.path.join(path, filename))):
             self._dircontent.value = self._map_name_to_disp[filename]
         else:
             self._dircontent.value = None
@@ -219,7 +218,7 @@ class FileChooser(VBox):
 
             # Only check selected if selected is set
             if ((self._selected_path is not None) and
-                    self._selected_filename is not None):
+                    (self._selected_filename is not None)):
                 selected = os.path.join(
                     self._selected_path,
                     self._selected_filename

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -8,19 +8,19 @@ class FileChooser(VBox):
     """FileChooser class."""
 
     _LBL_TEMPLATE = '<span style="margin-left:10px; color:{1};">{0}</span>'
-    _LBL_NOFILE = "No file selected"
+    _LBL_NOFILE = 'No file selected'
 
     def __init__(
-        self,
-        path=os.getcwd(),
-        filename="",
-        title="",
-        select_desc="Select",
-        change_desc="Change",
-        show_hidden=False,
-        select_default=False,
-        use_dir_icons=False,
-        **kwargs
+            self,
+            path=os.getcwd(),
+            filename='',
+            title='',
+            select_desc='Select',
+            change_desc='Change',
+            show_hidden=False,
+            select_default=False,
+            use_dir_icons=False,
+            **kwargs
     ):
         """Initialize FileChooser object."""
         self._default_path = path.rstrip(os.path.sep)
@@ -35,61 +35,104 @@ class FileChooser(VBox):
 
         # Widgets
         self._pathlist = Dropdown(
-            description="", layout=Layout(width="auto", grid_area="pathlist")
+            description="",
+            layout=Layout(
+                width='auto',
+                grid_area='pathlist'
+            )
         )
         self._filename = Text(
-            placeholder="output filename",
-            layout=Layout(width="auto", grid_area="filename"),
+            placeholder='output filename',
+            layout=Layout(
+                width='auto',
+                grid_area='filename'
+            )
         )
         self._dircontent = Select(
-            rows=8, layout=Layout(width="auto", grid_area="dircontent")
+            rows=8,
+            layout=Layout(
+                width='auto',
+                grid_area='dircontent'
+            )
         )
         self._cancel = Button(
-            description="Cancel", layout=Layout(width="auto", display="none")
+            description='Cancel',
+            layout=Layout(
+                width='auto',
+                display='none'
+            )
         )
-        self._select = Button(description=self._select_desc, layout=Layout(width="auto"))
+        self._select = Button(
+            description=self._select_desc,
+            layout=Layout(width='auto')
+        )
 
-        self._title = HTML(value=title)
+        self._title = HTML(
+            value=title
+        )
 
-        if title == "":
-            self._title.layout.display = "none"
+        if title == '':
+            self._title.layout.display = 'none'
 
         # Widget observe handlers
-        self._pathlist.observe(self._on_pathlist_select, names="value")
-        self._dircontent.observe(self._on_dircontent_select, names="value")
-        self._filename.observe(self._on_filename_change, names="value")
+        self._pathlist.observe(
+            self._on_pathlist_select,
+            names='value'
+        )
+        self._dircontent.observe(
+            self._on_dircontent_select,
+            names='value'
+        )
+        self._filename.observe(
+            self._on_filename_change,
+            names='value'
+        )
         self._select.on_click(self._on_select_click)
         self._cancel.on_click(self._on_cancel_click)
 
         # Selected file label
         self._label = HTML(
-            value=self._LBL_TEMPLATE.format(self._LBL_NOFILE, "black"),
-            placeholder="",
-            description="",
+            value=self._LBL_TEMPLATE.format(
+                self._LBL_NOFILE,
+                'black'
+            ),
+            placeholder='',
+            description='',
         )
 
         # Layout
         self._gb = GridBox(
-            children=[self._pathlist, self._filename, self._dircontent],
+            children=[
+                self._pathlist,
+                self._filename,
+                self._dircontent
+            ],
             layout=Layout(
-                display="none",
-                width="500px",
-                grid_gap="0px 0px",
-                grid_template_rows="auto auto",
-                grid_template_columns="60% 40%",
+                display='none',
+                width='500px',
+                grid_gap='0px 0px',
+                grid_template_rows='auto auto',
+                grid_template_columns='60% 40%',
                 grid_template_areas="""
                     'pathlist filename'
                     'dircontent dircontent'
-                    """,
-            ),
+                    """
+            )
         )
         buttonbar = HBox(
-            children=[self._select, self._cancel, self._label],
-            layout=Layout(width="auto"),
+            children=[
+                self._select,
+                self._cancel,
+                self._label
+            ],
+            layout=Layout(width='auto'),
         )
 
         # Call setter to set initial form values
-        self._set_form_values(self._default_path, self._default_filename)
+        self._set_form_values(
+            self._default_path,
+            self._default_filename
+        )
 
         # Use the defaults as the selected values
         if select_default:
@@ -97,8 +140,12 @@ class FileChooser(VBox):
 
         # Call VBox super class __init__
         super().__init__(
-            children=[self._title, self._gb, buttonbar,],
-            layout=Layout(width="auto"),
+            children=[
+                self._title,
+                self._gb,
+                buttonbar,
+            ],
+            layout=Layout(width='auto'),
             **kwargs
         )
 
@@ -106,9 +153,18 @@ class FileChooser(VBox):
         """Set the form values."""
         # Disable triggers to prevent selecting an entry in the Select
         # box from automatically triggering a new event.
-        self._pathlist.unobserve(self._on_pathlist_select, names="value")
-        self._dircontent.unobserve(self._on_dircontent_select, names="value")
-        self._filename.unobserve(self._on_filename_change, names="value")
+        self._pathlist.unobserve(
+            self._on_pathlist_select,
+            names='value'
+        )
+        self._dircontent.unobserve(
+            self._on_dircontent_select,
+            names='value'
+        )
+        self._filename.unobserve(
+            self._on_filename_change,
+            names='value'
+        )
 
         # Set form values
         self._pathlist.options = get_subpaths(path)
@@ -131,17 +187,26 @@ class FileChooser(VBox):
 
         # If the value in the filename Text box equals a value in the
         # Select box and the entry is a file then select the entry.
-        if (filename in dircontent_real_names) and os.path.isfile(
-            os.path.join(path, filename)
+        if ((filename in dircontent_real_names) and
+                os.path.isfile(os.path.join(path, filename))
         ):
             self._dircontent.value = self._map_name_to_disp[filename]
         else:
             self._dircontent.value = None
 
         # Reenable triggers again
-        self._pathlist.observe(self._on_pathlist_select, names="value")
-        self._dircontent.observe(self._on_dircontent_select, names="value")
-        self._filename.observe(self._on_filename_change, names="value")
+        self._pathlist.observe(
+            self._on_pathlist_select,
+            names='value'
+        )
+        self._dircontent.observe(
+            self._on_dircontent_select,
+            names='value'
+        )
+        self._filename.observe(
+            self._on_filename_change,
+            names='value'
+        )
 
         # Update the state of the select button
         if self._gb.layout.display is None:
@@ -153,10 +218,12 @@ class FileChooser(VBox):
             check3 = False
 
             # Only check selected if selected is set
-            if (self._selected_path is not None) and (
-                self._selected_filename is not None
-            ):
-                selected = os.path.join(self._selected_path, self._selected_filename)
+            if ((self._selected_path is not None) and
+                    self._selected_filename is not None):
+                selected = os.path.join(
+                    self._selected_path,
+                    self._selected_filename
+                )
                 check3 = os.path.join(path, filename) == selected
 
             if (check1 and check2) or check3:
@@ -166,12 +233,15 @@ class FileChooser(VBox):
 
     def _on_pathlist_select(self, change):
         """Handle selecting a path entry."""
-        self._set_form_values(change["new"], self._filename.value)
+        self._set_form_values(
+            change['new'],
+            self._filename.value
+        )
 
     def _on_dircontent_select(self, change):
         """Handle selecting a folder entry."""
         new_path = os.path.realpath(
-            os.path.join(self._pathlist.value, self._map_disp_to_name[change["new"]])
+            os.path.join(self._pathlist.value, self._map_disp_to_name[change['new']])
         )
 
         # Check if folder or file
@@ -180,17 +250,23 @@ class FileChooser(VBox):
             filename = self._filename.value
         elif os.path.isfile(new_path):
             path = self._pathlist.value
-            filename = self._map_disp_to_name[change["new"]]
+            filename = self._map_disp_to_name[change['new']]
 
-        self._set_form_values(path, filename)
+        self._set_form_values(
+            path,
+            filename
+        )
 
     def _on_filename_change(self, change):
         """Handle filename field changes."""
-        self._set_form_values(self._pathlist.value, change["new"])
+        self._set_form_values(
+            self._pathlist.value,
+            change['new']
+        )
 
     def _on_select_click(self, b):
         """Handle select button clicks."""
-        if self._gb.layout.display == "none":
+        if self._gb.layout.display == 'none':
             # If not shown, open the dialog
             self._show_dialog()
         else:
@@ -212,7 +288,8 @@ class FileChooser(VBox):
         self._cancel.layout.display = None
 
         # Show the form with the correct path and filename
-        if (self._selected_path is not None) and (self._selected_filename is not None):
+        if ((self._selected_path is not None) and
+                (self._selected_filename is not None)):
             path = self._selected_path
             filename = self._selected_filename
         else:
@@ -223,31 +300,43 @@ class FileChooser(VBox):
 
     def _apply_selection(self):
         """Close the dialog and apply the selection."""
-        self._gb.layout.display = "none"
-        self._cancel.layout.display = "none"
+        self._gb.layout.display = 'none'
+        self._cancel.layout.display = 'none'
         self._select.description = self._change_desc
         self._selected_path = self._pathlist.value
         self._selected_filename = self._filename.value
 
-        selected = os.path.join(self._selected_path, self._selected_filename)
+        selected = os.path.join(
+            self._selected_path,
+            self._selected_filename
+        )
 
         if os.path.isfile(selected):
-            self._label.value = self._LBL_TEMPLATE.format(selected, "orange")
+            self._label.value = self._LBL_TEMPLATE.format(
+                selected,
+                'orange'
+            )
         else:
-            self._label.value = self._LBL_TEMPLATE.format(selected, "green")
+            self._label.value = self._LBL_TEMPLATE.format(
+                selected,
+                'green'
+            )
 
     def _on_cancel_click(self, b):
         """Handle cancel button clicks."""
-        self._gb.layout.display = "none"
-        self._cancel.layout.display = "none"
+        self._gb.layout.display = 'none'
+        self._cancel.layout.display = 'none'
         self._select.disabled = False
 
     def reset(self, path=None, filename=None):
         """Reset the form to the default path and filename."""
-        self._selected_path = ""
-        self._selected_filename = ""
+        self._selected_path = ''
+        self._selected_filename = ''
 
-        self._label.value = self._LBL_TEMPLATE.format(self._LBL_NOFILE, "black")
+        self._label.value = self._LBL_TEMPLATE.format(
+            self._LBL_NOFILE,
+            'black'
+        )
 
         if path is not None:
             self._default_path = path.rstrip(os.path.sep)
@@ -255,11 +344,17 @@ class FileChooser(VBox):
         if filename is not None:
             self._default_filename = filename
 
-        self._set_form_values(self._default_path, self._default_filename)
+        self._set_form_values(
+            self._default_path,
+            self._default_filename
+        )
 
     def refresh(self):
         """Re-render the form."""
-        self._set_form_values(self._pathlist.value, self._filename.value)
+        self._set_form_values(
+            self._pathlist.value,
+            self._filename.value
+        )
 
     @property
     def show_hidden(self):
@@ -292,15 +387,18 @@ class FileChooser(VBox):
         """Set the title."""
         self._title.value = title
 
-        if title == "":
-            self._title.layout.display = "none"
+        if title == '':
+            self._title.layout.display = 'none'
         else:
             self._title.layout.display = None
 
     @property
     def default(self):
         """Get the default value."""
-        return os.path.join(self._default_path, self._default_filename)
+        return os.path.join(
+            self._default_path,
+            self._default_filename
+        )
 
     @property
     def default_path(self):
@@ -311,7 +409,10 @@ class FileChooser(VBox):
     def default_path(self, path):
         """Set the default_path."""
         self._default_path = path.rstrip(os.path.sep)
-        self._set_form_values(self._default_path, self._filename.value)
+        self._set_form_values(
+            self._default_path,
+            self._filename.value
+        )
 
     @property
     def default_filename(self):
@@ -322,13 +423,19 @@ class FileChooser(VBox):
     def default_filename(self, filename):
         """Set the default_filename."""
         self._default_filename = filename
-        self._set_form_values(self._pathlist.value, self._default_filename)
+        self._set_form_values(
+            self._pathlist.value,
+            self._default_filename
+        )
 
     @property
     def selected(self):
         """Get selected value."""
         try:
-            return os.path.join(self._selected_path, self._selected_filename)
+            return os.path.join(
+                self._selected_path,
+                self._selected_filename
+            )
         except TypeError:
             return None
 
@@ -344,9 +451,14 @@ class FileChooser(VBox):
 
     def __repr__(self):
         """Build string representation."""
-        str_ = (
-            "FileChooser(" "path='{0}', " "filename='{1}', " "show_hidden='{2}')"
-        ).format(self._default_path, self._default_filename, self._show_hidden)
+        str_ = ("FileChooser("
+                "path='{0}', "
+                "filename='{1}', "
+                "show_hidden='{2}')").format(
+            self._default_path,
+            self._default_filename,
+            self._show_hidden
+        )
         return str_
 
     def register_callback(self, callback):

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -8,18 +8,20 @@ class FileChooser(VBox):
     """FileChooser class."""
 
     _LBL_TEMPLATE = '<span style="margin-left:10px; color:{1};">{0}</span>'
-    _LBL_NOFILE = 'No file selected'
+    _LBL_NOFILE = "No file selected"
 
     def __init__(
-            self,
-            path=os.getcwd(),
-            filename='',
-            title='',
-            select_desc='Select',
-            change_desc='Change',
-            show_hidden=False,
-            select_default=False,
-            **kwargs):
+        self,
+        path=os.getcwd(),
+        filename="",
+        title="",
+        select_desc="Select",
+        change_desc="Change",
+        show_hidden=False,
+        select_default=False,
+        use_dir_icons=False,
+        **kwargs
+    ):
         """Initialize FileChooser object."""
         self._default_path = path.rstrip(os.path.sep)
         self._default_filename = filename
@@ -29,107 +31,65 @@ class FileChooser(VBox):
         self._select_desc = select_desc
         self._change_desc = change_desc
         self._callback = None
+        self._dir_icons = use_dir_icons
 
         # Widgets
         self._pathlist = Dropdown(
-            description="",
-            layout=Layout(
-                width='auto',
-                grid_area='pathlist'
-            )
+            description="", layout=Layout(width="auto", grid_area="pathlist")
         )
         self._filename = Text(
-            placeholder='output filename',
-            layout=Layout(
-                width='auto',
-                grid_area='filename'
-            )
+            placeholder="output filename",
+            layout=Layout(width="auto", grid_area="filename"),
         )
         self._dircontent = Select(
-            rows=8,
-            layout=Layout(
-                width='auto',
-                grid_area='dircontent'
-            )
+            rows=8, layout=Layout(width="auto", grid_area="dircontent")
         )
         self._cancel = Button(
-            description='Cancel',
-            layout=Layout(
-                width='auto',
-                display='none'
-            )
+            description="Cancel", layout=Layout(width="auto", display="none")
         )
-        self._select = Button(
-            description=self._select_desc,
-            layout=Layout(width='auto')
-        )
+        self._select = Button(description=self._select_desc, layout=Layout(width="auto"))
 
-        self._title = HTML(
-            value=title
-        )
+        self._title = HTML(value=title)
 
-        if title == '':
-            self._title.layout.display = 'none'
+        if title == "":
+            self._title.layout.display = "none"
 
         # Widget observe handlers
-        self._pathlist.observe(
-            self._on_pathlist_select,
-            names='value'
-        )
-        self._dircontent.observe(
-            self._on_dircontent_select,
-            names='value'
-        )
-        self._filename.observe(
-            self._on_filename_change,
-            names='value'
-        )
+        self._pathlist.observe(self._on_pathlist_select, names="value")
+        self._dircontent.observe(self._on_dircontent_select, names="value")
+        self._filename.observe(self._on_filename_change, names="value")
         self._select.on_click(self._on_select_click)
         self._cancel.on_click(self._on_cancel_click)
 
         # Selected file label
         self._label = HTML(
-            value=self._LBL_TEMPLATE.format(
-                self._LBL_NOFILE,
-                'black'
-            ),
-            placeholder='',
-            description=''
+            value=self._LBL_TEMPLATE.format(self._LBL_NOFILE, "black"),
+            placeholder="",
+            description="",
         )
 
         # Layout
         self._gb = GridBox(
-            children=[
-                self._pathlist,
-                self._filename,
-                self._dircontent
-            ],
+            children=[self._pathlist, self._filename, self._dircontent],
             layout=Layout(
-                display='none',
-                width='500px',
-                grid_gap='0px 0px',
-                grid_template_rows='auto auto',
-                grid_template_columns='60% 40%',
-                grid_template_areas='''
+                display="none",
+                width="500px",
+                grid_gap="0px 0px",
+                grid_template_rows="auto auto",
+                grid_template_columns="60% 40%",
+                grid_template_areas="""
                     'pathlist filename'
                     'dircontent dircontent'
-                    '''
-            )
+                    """,
+            ),
         )
         buttonbar = HBox(
-            children=[
-                self._select,
-                self._cancel,
-                self._label
-            ],
-            layout=Layout(width='auto')
+            children=[self._select, self._cancel, self._label],
+            layout=Layout(width="auto"),
         )
 
         # Call setter to set initial form values
-        self._set_form_values(
-            self._default_path,
-            self._default_filename
-        )
+        self._set_form_values(self._default_path, self._default_filename)
 
         # Use the defaults as the selected values
         if select_default:
@@ -137,12 +97,8 @@ class FileChooser(VBox):
 
         # Call VBox super class __init__
         super().__init__(
-            children=[
-                self._title,
-                self._gb,
-                buttonbar,
-            ],
-            layout=Layout(width='auto'),
+            children=[self._title, self._gb, buttonbar,],
+            layout=Layout(width="auto"),
             **kwargs
         )
 
@@ -150,67 +106,58 @@ class FileChooser(VBox):
         """Set the form values."""
         # Disable triggers to prevent selecting an entry in the Select
         # box from automatically triggering a new event.
-        self._pathlist.unobserve(
-            self._on_pathlist_select,
-            names='value'
-        )
-        self._dircontent.unobserve(
-            self._on_dircontent_select,
-            names='value'
-        )
-        self._filename.unobserve(
-            self._on_filename_change,
-            names='value'
-        )
+        self._pathlist.unobserve(self._on_pathlist_select, names="value")
+        self._dircontent.unobserve(self._on_dircontent_select, names="value")
+        self._filename.unobserve(self._on_filename_change, names="value")
 
         # Set form values
         self._pathlist.options = get_subpaths(path)
         self._pathlist.value = path
         self._filename.value = filename
-        self._dircontent.options = get_dir_contents(
-            path,
-            hidden=self._show_hidden
+        dircontent_real_names = get_dir_contents(
+            path, hidden=self._show_hidden, prepend_icons=False
         )
+        dircontent_display_names = get_dir_contents(
+            path, hidden=self._show_hidden, prepend_icons=self._dir_icons
+        )
+        self._map_name_to_disp = {
+            disp: val
+            for disp, val in zip(dircontent_real_names, dircontent_display_names)
+        }
+        self._map_disp_to_name = dict(
+            reversed(item) for item in self._map_name_to_disp.items()
+        )
+        self._dircontent.options = dircontent_display_names
 
         # If the value in the filename Text box equals a value in the
         # Select box and the entry is a file then select the entry.
-        if ((filename in self._dircontent.options) and
-                os.path.isfile(os.path.join(path, filename))):
-            self._dircontent.value = filename
+        if (filename in dircontent_real_names) and os.path.isfile(
+            os.path.join(path, filename)
+        ):
+            self._dircontent.value = self._map_name_to_disp[filename]
         else:
             self._dircontent.value = None
 
         # Reenable triggers again
-        self._pathlist.observe(
-            self._on_pathlist_select,
-            names='value'
-        )
-        self._dircontent.observe(
-            self._on_dircontent_select,
-            names='value'
-        )
-        self._filename.observe(
-            self._on_filename_change,
-            names='value'
-        )
+        self._pathlist.observe(self._on_pathlist_select, names="value")
+        self._dircontent.observe(self._on_dircontent_select, names="value")
+        self._filename.observe(self._on_filename_change, names="value")
 
         # Update the state of the select button
         if self._gb.layout.display is None:
             # Disable the select button if path and filename
             # - equal an existing folder in the current view
             # - equal the already selected values
-            check1 = (filename in self._dircontent.options)
-            check2 = (os.path.isdir(os.path.join(path, filename)))
+            check1 = filename in dircontent_real_names
+            check2 = os.path.isdir(os.path.join(path, filename))
             check3 = False
 
             # Only check selected if selected is set
-            if ((self._selected_path is not None) and
-                    (self._selected_filename is not None)):
-                selected = os.path.join(
-                    self._selected_path,
-                    self._selected_filename
-                )
-                check3 = (os.path.join(path, filename) == selected)
+            if (self._selected_path is not None) and (
+                self._selected_filename is not None
+            ):
+                selected = os.path.join(self._selected_path, self._selected_filename)
+                check3 = os.path.join(path, filename) == selected
 
             if (check1 and check2) or check3:
                 self._select.disabled = True
@@ -219,15 +166,12 @@ class FileChooser(VBox):
 
     def _on_pathlist_select(self, change):
         """Handle selecting a path entry."""
-        self._set_form_values(
-            change['new'],
-            self._filename.value
-        )
+        self._set_form_values(change["new"], self._filename.value)
 
     def _on_dircontent_select(self, change):
         """Handle selecting a folder entry."""
         new_path = os.path.realpath(
-            os.path.join(self._pathlist.value, change['new'])
+            os.path.join(self._pathlist.value, self._map_disp_to_name[change["new"]])
         )
 
         # Check if folder or file
@@ -236,23 +180,17 @@ class FileChooser(VBox):
             filename = self._filename.value
         elif os.path.isfile(new_path):
             path = self._pathlist.value
-            filename = change['new']
+            filename = self._map_disp_to_name[change["new"]]
 
-        self._set_form_values(
-            path,
-            filename
-        )
+        self._set_form_values(path, filename)
 
     def _on_filename_change(self, change):
         """Handle filename field changes."""
-        self._set_form_values(
-            self._pathlist.value,
-            change['new']
-        )
+        self._set_form_values(self._pathlist.value, change["new"])
 
     def _on_select_click(self, b):
         """Handle select button clicks."""
-        if self._gb.layout.display == 'none':
+        if self._gb.layout.display == "none":
             # If not shown, open the dialog
             self._show_dialog()
         else:
@@ -269,8 +207,7 @@ class FileChooser(VBox):
         self._cancel.layout.display = None
 
         # Show the form with the correct path and filename
-        if ((self._selected_path is not None) and
-                (self._selected_filename is not None)):
+        if (self._selected_path is not None) and (self._selected_filename is not None):
             path = self._selected_path
             filename = self._selected_filename
         else:
@@ -281,43 +218,31 @@ class FileChooser(VBox):
 
     def _apply_selection(self):
         """Close the dialog and apply the selection."""
-        self._gb.layout.display = 'none'
-        self._cancel.layout.display = 'none'
+        self._gb.layout.display = "none"
+        self._cancel.layout.display = "none"
         self._select.description = self._change_desc
         self._selected_path = self._pathlist.value
         self._selected_filename = self._filename.value
 
-        selected = os.path.join(
-            self._selected_path,
-            self._selected_filename
-        )
+        selected = os.path.join(self._selected_path, self._selected_filename)
 
         if os.path.isfile(selected):
-            self._label.value = self._LBL_TEMPLATE.format(
-                selected,
-                'orange'
-            )
+            self._label.value = self._LBL_TEMPLATE.format(selected, "orange")
         else:
-            self._label.value = self._LBL_TEMPLATE.format(
-                selected,
-                'green'
-            )
+            self._label.value = self._LBL_TEMPLATE.format(selected, "green")
 
     def _on_cancel_click(self, b):
         """Handle cancel button clicks."""
-        self._gb.layout.display = 'none'
-        self._cancel.layout.display = 'none'
+        self._gb.layout.display = "none"
+        self._cancel.layout.display = "none"
         self._select.disabled = False
 
     def reset(self, path=None, filename=None):
         """Reset the form to the default path and filename."""
-        self._selected_path = ''
-        self._selected_filename = ''
+        self._selected_path = ""
+        self._selected_filename = ""
 
-        self._label.value = self._LBL_TEMPLATE.format(
-            self._LBL_NOFILE,
-            'black'
-        )
+        self._label.value = self._LBL_TEMPLATE.format(self._LBL_NOFILE, "black")
 
         if path is not None:
             self._default_path = path.rstrip(os.path.sep)
@@ -325,17 +250,11 @@ class FileChooser(VBox):
         if filename is not None:
             self._default_filename = filename
 
-        self._set_form_values(
-            self._default_path,
-            self._default_filename
-        )
+        self._set_form_values(self._default_path, self._default_filename)
 
     def refresh(self):
         """Re-render the form."""
-        self._set_form_values(
-            self._pathlist.value,
-            self._filename.value
-        )
+        self._set_form_values(self._pathlist.value, self._filename.value)
 
     @property
     def show_hidden(self):
@@ -368,18 +287,15 @@ class FileChooser(VBox):
         """Set the title."""
         self._title.value = title
 
-        if title == '':
-            self._title.layout.display = 'none'
+        if title == "":
+            self._title.layout.display = "none"
         else:
             self._title.layout.display = None
 
     @property
     def default(self):
         """Get the default value."""
-        return os.path.join(
-            self._default_path,
-            self._default_filename
-        )
+        return os.path.join(self._default_path, self._default_filename)
 
     @property
     def default_path(self):
@@ -390,10 +306,7 @@ class FileChooser(VBox):
     def default_path(self, path):
         """Set the default_path."""
         self._default_path = path.rstrip(os.path.sep)
-        self._set_form_values(
-            self._default_path,
-            self._filename.value
-        )
+        self._set_form_values(self._default_path, self._filename.value)
 
     @property
     def default_filename(self):
@@ -404,19 +317,13 @@ class FileChooser(VBox):
     def default_filename(self, filename):
         """Set the default_filename."""
         self._default_filename = filename
-        self._set_form_values(
-            self._pathlist.value,
-            self._default_filename
-        )
+        self._set_form_values(self._pathlist.value, self._default_filename)
 
     @property
     def selected(self):
         """Get selected value."""
         try:
-            return os.path.join(
-                self._selected_path,
-                self._selected_filename
-            )
+            return os.path.join(self._selected_path, self._selected_filename)
         except TypeError:
             return None
 
@@ -432,14 +339,9 @@ class FileChooser(VBox):
 
     def __repr__(self):
         """Build string representation."""
-        str_ = ("FileChooser("
-                "path='{0}', "
-                "filename='{1}', "
-                "show_hidden='{2}')").format(
-            self._default_path,
-            self._default_filename,
-            self._show_hidden
-        )
+        str_ = (
+            "FileChooser(" "path='{0}', " "filename='{1}', " "show_hidden='{2}')"
+        ).format(self._default_path, self._default_filename, self._show_hidden)
         return str_
 
     def register_callback(self, callback):

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -178,7 +178,8 @@ class FileChooser(VBox):
         )
         self._map_name_to_disp = {
             disp: val
-            for disp, val in zip(dircontent_real_names, dircontent_display_names)
+            for disp, val in zip(dircontent_real_names,
+                                 dircontent_display_names)
         }
         self._map_disp_to_name = dict(
             reversed(item) for item in self._map_name_to_disp.items()
@@ -240,7 +241,8 @@ class FileChooser(VBox):
     def _on_dircontent_select(self, change):
         """Handle selecting a folder entry."""
         new_path = os.path.realpath(
-            os.path.join(self._pathlist.value, self._map_disp_to_name[change['new']])
+            os.path.join(
+                self._pathlist.value, self._map_disp_to_name[change['new']])
         )
 
         # Check if folder or file

--- a/ipyfilechooser/utils.py
+++ b/ipyfilechooser/utils.py
@@ -31,7 +31,7 @@ def has_parent(path):
     return os.path.basename(path) != ''
 
 
-def get_dir_contents(path, hidden=False):
+def get_dir_contents(path, hidden=False, prepend_icons=False):
     """Get directory contents."""
     files = list()
     dirs = list()
@@ -48,7 +48,13 @@ def get_dir_contents(path, hidden=False):
                 files.append(item)
         if has_parent(path):
             dirs.insert(0, '..')
-    return sorted(dirs) + sorted(files)
+    if prepend_icons:
+        return prepend_dir_icons(sorted(dirs)) + sorted(files)
+    else:
+        return sorted(dirs) + sorted(files)
+
+def prepend_dir_icons(dir_list):
+   return ["\U0001F4C1 " + dirname for dirname in dir_list]
 
 
 def get_drive_letters():

--- a/ipyfilechooser/utils.py
+++ b/ipyfilechooser/utils.py
@@ -53,8 +53,9 @@ def get_dir_contents(path, hidden=False, prepend_icons=False):
     else:
         return sorted(dirs) + sorted(files)
 
+
 def prepend_dir_icons(dir_list):
-   return ["\U0001F4C1 " + dirname for dirname in dir_list]
+    return ["\U0001F4C1 " + dirname for dirname in dir_list]
 
 
 def get_drive_letters():


### PR DESCRIPTION
Adds an option to use unicode folder character to denote directories in the chooser dialog:

![image](https://user-images.githubusercontent.com/32297355/74519488-b2228f80-4f0d-11ea-9760-9bcf92cfb9f2.png)

It adds a `use_dir_icons=False` keyword option to the filechooser constructor and I have left it disabled by default for now.