### PR TITLE
Add show_only_folders property

### DIFF
--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -334,16 +334,18 @@ class FileChooser(VBox):
             self._selected_filename
         )
 
-        if os.path.isfile(selected):
-            self._label.value = self._LBL_TEMPLATE.format(
-                selected,
-                'orange'
-            )
+        if self._show_only_folders:
+            overwrite_flag = os.path.exists(selected)
         else:
-            self._label.value = self._LBL_TEMPLATE.format(
-                selected,
-                'green'
-            )
+            overwrite_flag = os.path.isfile(selected)
+        if overwrite_flag:
+            label_color = 'orange'
+        else:
+            label_color = 'green'
+        self._label.value = self._LBL_TEMPLATE.format(
+            selected,
+            label_color
+        )
 
     def _on_cancel_click(self, b):
         """Handle cancel button clicks."""

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -20,6 +20,7 @@ class FileChooser(VBox):
             show_hidden=False,
             select_default=False,
             use_dir_icons=False,
+            show_only_folders=False,
             **kwargs
     ):
         """Initialize FileChooser object."""
@@ -32,6 +33,7 @@ class FileChooser(VBox):
         self._change_desc = change_desc
         self._callback = None
         self._use_dir_icons = use_dir_icons
+        self._show_only_folders = show_only_folders
 
         # Widgets
         self._pathlist = Dropdown(
@@ -175,14 +177,16 @@ class FileChooser(VBox):
         dircontent_real_names = get_dir_contents(
             path,
             hidden=self._show_hidden,
-            prepend_icons=False
+            prepend_icons=False,
+            show_only_folders=self._show_only_folders
         )
 
         # file/folder display names
         dircontent_display_names = get_dir_contents(
             path,
             hidden=self._show_hidden,
-            prepend_icons=self._use_dir_icons
+            prepend_icons=self._use_dir_icons,
+            show_only_folders=self._show_only_folders
         )
 
         # Dict to map real names to display names
@@ -478,6 +482,20 @@ class FileChooser(VBox):
     def selected_filename(self):
         """Get the selected_filename."""
         return self._selected_filename
+
+    @property
+    def show_only_folders(self):
+        """Get show_only_folders property value."""
+        return self._show_only_folders
+
+    @show_only_folders.setter
+    def show_only_folders(self, flag):
+        """Set show_only_folders property value."""
+        self._show_only_folders = flag
+        self._set_form_values(
+            self._selected_path,
+            self._selected_filename
+        )
 
     def __repr__(self):
         """Build string representation."""

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -48,7 +48,8 @@ class FileChooser(VBox):
             layout=Layout(
                 width='auto',
                 grid_area='filename'
-            )
+            ),
+            disabled=self._show_only_folders
         )
         self._dircontent = Select(
             rows=8,
@@ -494,6 +495,7 @@ class FileChooser(VBox):
     def show_only_folders(self, flag):
         """Set show_only_folders property value."""
         self._show_only_folders = flag
+        self._filename.disabled = self._show_only_folders
         self._set_form_values(
             self._selected_path,
             self._selected_filename

--- a/ipyfilechooser/utils.py
+++ b/ipyfilechooser/utils.py
@@ -31,7 +31,10 @@ def has_parent(path):
     return os.path.basename(path) != ''
 
 
-def get_dir_contents(path, hidden=False, prepend_icons=False):
+def get_dir_contents(path,
+                     hidden=False,
+                     prepend_icons=False,
+                     show_only_folders=False):
     """Get directory contents."""
     files = list()
     dirs = list()
@@ -44,7 +47,7 @@ def get_dir_contents(path, hidden=False, prepend_icons=False):
             full_item = os.path.join(path, item)
             if os.path.isdir(full_item) and append:
                 dirs.append(item)
-            elif append:
+            elif append and (not show_only_folders):
                 files.append(item)
         if has_parent(path):
             dirs.insert(0, '..')


### PR DESCRIPTION
Hi @crahan 

I've added `show_only_folders` property to `FileChooser` class.

It may be useful in cases when the user is asked to select a folder (ie output folder for saving multiple generated files).

Please let me know if you have any comments.

Thanks.

Andrii