### PR TITLE
Prevent selection if filter_pattern mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ fc.selected_filename
 
 ## Release notes
 
+### 0.4.3
+
+- Prevent applying the selected value if the filename doesn't match one of the `filter_pattern` values
+
 ### 0.4.2
 
 - Added ability to specify a list of `fnmatch` pattern strings for `filter_pattern`

--- a/ipyfilechooser/__init__.py
+++ b/ipyfilechooser/__init__.py
@@ -1,3 +1,3 @@
 from .filechooser import FileChooser
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -1,7 +1,7 @@
 import os
 from ipywidgets import Dropdown, Text, Select, Button, HTML
 from ipywidgets import Layout, GridBox, HBox, VBox, ValueWidget
-from .utils import get_subpaths, get_dir_contents
+from .utils import get_subpaths, get_dir_contents, match_item
 
 
 class FileChooser(VBox, ValueWidget):
@@ -244,9 +244,11 @@ class FileChooser(VBox, ValueWidget):
             # Disable the select button if path and filename
             # - equal an existing folder in the current view
             # - equal the already selected values
+            # - don't match the provided filter pattern(s)
             check1 = filename in dircontent_real_names
             check2 = os.path.isdir(os.path.join(path, filename))
             check3 = False
+            check4 = False
 
             # Only check selected if selected is set
             if ((self._selected_path is not None) and
@@ -257,7 +259,11 @@ class FileChooser(VBox, ValueWidget):
                 )
                 check3 = os.path.join(path, filename) == selected
 
-            if (check1 and check2) or check3:
+            # Ensure only allowed extensions are used
+            if self._filter_pattern:
+                check4 = not match_item(filename, self._filter_pattern)
+
+            if (check1 and check2) or check3 or check4:
                 self._select.disabled = True
             else:
                 self._select.disabled = False

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name='ipyfilechooser',
-    version='0.4.2',
+    version='0.4.3',
     author='Thomas Bouve (@crahan)',
     author_email='crahan@n00.be',
     description=(


### PR DESCRIPTION
The chosen file name should match the `pattern_filter` list before the selection can be applied.