### PR TITLE
Remove deprecated key from .travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: xenial
 language: python
-sudo: false
 python:
   - "3.7"
 # command to install dependencies


### PR DESCRIPTION
The key `sudo` has no effect anymore.