### PR TITLE
Fix warning of referenced before assignment

### DIFF
--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -290,7 +290,7 @@ class FileChooser(VBox, ValueWidget):
         if os.path.isdir(new_path):
             path = new_path
             filename = self._filename.value
-        elif os.path.isfile(new_path):
+        else:
             path = self._pathlist.value
             filename = self._map_disp_to_name[change['new']]
 


### PR DESCRIPTION
I would recommend to use GitHub rebase instead of merge for PRs, to avoid adding those merge commits messages and keep the history flattened.

![image](https://user-images.githubusercontent.com/31109774/119121406-5fcafb00-b9fb-11eb-9f0d-06f36dd99521.png)
