### PR TITLE
filter_pattern is now case-insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ fc.selected_filename
 
 ## Release notes
 
+### 0.4.4
+
+- Added typing hints (@Mandroide)
+- Updated max line length check from 90 to 120 characters
+- Fixed `filter_pattern` values not being treated as case-insensitive
+- General code cleanup
+
 ### 0.4.3
 
 - Prevent applying the selected value if the filename doesn't match one of the `filter_pattern` values

--- a/ipyfilechooser/__init__.py
+++ b/ipyfilechooser/__init__.py
@@ -1,3 +1,3 @@
 from .filechooser import FileChooser
 
-__version__ = '0.4.3'
+__version__ = '0.4.4'

--- a/ipyfilechooser/utils.py
+++ b/ipyfilechooser/utils.py
@@ -42,7 +42,7 @@ def match_item(item: str, filter_pattern: Sequence[str]) -> bool:
     found = False
 
     while idx < len(filter_pattern) and not found:
-        found |= fnmatch.fnmatch(item, filter_pattern[idx])
+        found |= fnmatch.fnmatch(item.lower(), filter_pattern[idx].lower())
         idx += 1
 
     return found

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname: str) -> str:
 
 setup(
     name='ipyfilechooser',
-    version='0.4.3',
+    version='0.4.4',
     author='Thomas Bouve (@crahan)',
     author_email='crahan@n00.be',
     description=(


### PR DESCRIPTION
- Added typing hints (@Mandroide)
- Updated max line length check from 90 to 120 characters
- Fixed `filter_pattern` values not being treated as case-insensitive
- General code cleanup