### PR TITLE
Configure width, folder path sanitizing, cleaner layout, support value property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,28 @@
-#Ignore vscode individual settings
-.vscode
+# Ignore  macOS .DS_Store files
+.DS_Store
 
-#Ignore egg-info files and folders
-*.egg-info
+# Ignore backup files
+*~
+
+# Ignore vscode individual settings
+.vscode/
+
+# Ignore egg-info files and folders
+*.egg-info/
 *.pyc
 
-#Ignore pyenv version files
+# Ignore pyenv version files
 .python-version
 
-#Ignore build and dist folders
-build/*
-dist/*
+# Ignore build and dist folders
+build/
+dist/
 
-# Jupyter notebook checkpoints
-.ipynb_checkpoints
+# Ignore __pycache__ folder
+__pycache__/
+
+# Ignore Python virtualenv folder
+venv/
+
+# Ignore Jupyter notebook checkpoints
+.ipynb_checkpoints/

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -23,7 +23,7 @@ class FileChooser(VBox, ValueWidget):
             use_dir_icons: bool = False,
             show_only_dirs: bool = False,
             filter_pattern: Optional[Sequence[str]] = None,
-            layout: Layout = Layout(width='500px'),
+            width: str = '500px',
             **kwargs):
         """Initialize FileChooser object."""
         self._default_path = path.rstrip(os.path.sep)
@@ -104,7 +104,7 @@ class FileChooser(VBox, ValueWidget):
             ],
             layout=Layout(
                 display='none',
-                width='auto',
+                width=width,
                 grid_gap='0px 0px',
                 grid_template_rows='auto auto',
                 grid_template_columns='60% 40%',
@@ -138,7 +138,7 @@ class FileChooser(VBox, ValueWidget):
                 self._gb,
                 buttonbar
             ],
-            layout=layout,
+            layout=Layout(width='auto'),
             **kwargs
         )
 

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional, Sequence, Mapping, Callable
 from ipywidgets import Dropdown, Text, Select, Button, HTML
-from ipywidgets import Layout, GridBox, HBox, VBox, ValueWidget
+from ipywidgets import Layout, GridBox, Box, HBox, VBox, ValueWidget
 from .utils import get_subpaths, get_dir_contents, match_item
 
 
@@ -124,7 +124,7 @@ class FileChooser(VBox, ValueWidget):
             children=[
                 self._select,
                 self._cancel,
-                self._label
+                Box([self._label], layout=Layout(overflow='auto'))
             ],
             layout=Layout(width='auto')
         )

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -23,6 +23,7 @@ class FileChooser(VBox, ValueWidget):
             use_dir_icons: bool = False,
             show_only_dirs: bool = False,
             filter_pattern: Optional[Sequence[str]] = None,
+            layout: Layout = Layout(width='500px'),
             **kwargs):
         """Initialize FileChooser object."""
         self._default_path = path.rstrip(os.path.sep)
@@ -103,7 +104,7 @@ class FileChooser(VBox, ValueWidget):
             ],
             layout=Layout(
                 display='none',
-                width='500px',
+                width='auto',
                 grid_gap='0px 0px',
                 grid_template_rows='auto auto',
                 grid_template_columns='60% 40%',
@@ -137,7 +138,7 @@ class FileChooser(VBox, ValueWidget):
                 self._gb,
                 buttonbar
             ],
-            layout=Layout(width='auto'),
+            layout=layout,
             **kwargs
         )
 

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -26,7 +26,7 @@ class FileChooser(VBox, ValueWidget):
             layout: Layout = Layout(width='500px'),
             **kwargs):
         """Initialize FileChooser object."""
-        self._default_path = path.rstrip(os.path.sep)
+        self._default_path = os.path.normpath(path)
         self._default_filename = filename
         self._selected_path = None
         self._selected_filename = None
@@ -324,7 +324,7 @@ class FileChooser(VBox, ValueWidget):
         self._label.value = self._LBL_TEMPLATE.format(self._LBL_NOFILE, 'black')
 
         if path is not None:
-            self._default_path = path.rstrip(os.path.sep)
+            self._default_path = os.path.normpath(path)
 
         if filename is not None:
             self._default_filename = filename
@@ -405,7 +405,7 @@ class FileChooser(VBox, ValueWidget):
     @default_path.setter
     def default_path(self, path: str) -> None:
         """Set the default_path."""
-        self._default_path = path.rstrip(os.path.sep)
+        self._default_path = os.path.normpath(path)
         self._set_form_values(self._default_path, self._filename.value)
 
     @property

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -8,7 +8,7 @@ from .utils import get_subpaths, get_dir_contents, match_item
 class FileChooser(VBox, ValueWidget):
     """FileChooser class."""
 
-    _LBL_TEMPLATE = '<span style="margin-left:10px; color:{1};">{0}</span>'
+    _LBL_TEMPLATE = '<span style="color:{1};">{0}</span>'
     _LBL_NOFILE = 'No file selected'
 
     def __init__(
@@ -23,7 +23,7 @@ class FileChooser(VBox, ValueWidget):
             use_dir_icons: bool = False,
             show_only_dirs: bool = False,
             filter_pattern: Optional[Sequence[str]] = None,
-            width: str = '500px',
+            layout: Layout = Layout(width='500px'),
             **kwargs):
         """Initialize FileChooser object."""
         self._default_path = path.rstrip(os.path.sep)
@@ -66,13 +66,17 @@ class FileChooser(VBox, ValueWidget):
         self._cancel = Button(
             description='Cancel',
             layout=Layout(
-                width='auto',
+                min_width='6em',
+                width='6em',
                 display='none'
             )
         )
         self._select = Button(
             description=self._select_desc,
-            layout=Layout(width='auto')
+            layout=Layout(
+                min_width='6em',
+                width='6em'
+            )
         )
         self._title = HTML(
             value=title
@@ -92,7 +96,8 @@ class FileChooser(VBox, ValueWidget):
         self._label = HTML(
             value=self._LBL_TEMPLATE.format(self._LBL_NOFILE, 'black'),
             placeholder='',
-            description=''
+            description='',
+            layout=Layout(margin='0 0 0 1em')
         )
 
         # Layout
@@ -104,7 +109,7 @@ class FileChooser(VBox, ValueWidget):
             ],
             layout=Layout(
                 display='none',
-                width=width,
+                width='auto',
                 grid_gap='0px 0px',
                 grid_template_rows='auto auto',
                 grid_template_columns='60% 40%',
@@ -138,7 +143,7 @@ class FileChooser(VBox, ValueWidget):
                 self._gb,
                 buttonbar
             ],
-            layout=Layout(width='auto'),
+            layout=layout,
             **kwargs
         )
 

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -455,6 +455,11 @@ class FileChooser(VBox, ValueWidget):
         self.refresh()
 
     @property
+    def value(self) -> Optional[str]:
+        """Get selected value."""
+        return self.selected
+
+    @property
     def selected(self) -> Optional[str]:
         """Get selected value."""
         selected = None


### PR DESCRIPTION
Updates and fixes:

- the widget width is now configurable using the layout property and a`Layout` object (fixes #56)
- folder paths are now normalized using `os.path.normpath` which properly handles '/' and '\\' on Windows (fixes #59)
- the widget now support the `value` property to align with other widget types (fixes #57)
- the label showing the selected value now reflows the text to new lines as required (and shows a scrollbar if the value is too long)
- buttons now have a minimum width so text is always shown, regardless of widget width