### PR TITLE
Fix select_default property assignment and interaction

### DIFF
--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -431,6 +431,17 @@ class FileChooser(VBox, ValueWidget):
         self.refresh()
 
     @property
+    def select_default(self) -> bool:
+        """Get _select_default value."""
+        return self._select_default
+
+    @select_default.setter
+    def select_default(self, select_default: bool) -> None:
+        """Set _select_default value."""
+        self._select_default = select_default
+        self.refresh()
+
+    @property
     def dir_icon(self) -> Optional[str]:
         """Get dir icon value."""
         return self._dir_icon

--- a/ipyfilechooser/filechooser.py
+++ b/ipyfilechooser/filechooser.py
@@ -3,16 +3,19 @@ import warnings
 from typing import Optional, Sequence, Mapping, Callable
 from ipywidgets import Dropdown, Text, Select, Button, HTML
 from ipywidgets import Layout, GridBox, Box, HBox, VBox, ValueWidget
+from traitlets import HasTraits, Unicode
 from .errors import ParentPathError, InvalidFileNameError
 from .utils import get_subpaths, get_dir_contents, match_item, strip_parent_path
 from .utils import is_valid_filename, get_drive_letters, normalize_path, has_parent_path
 
 
-class FileChooser(VBox, ValueWidget):
+class FileChooser(VBox, ValueWidget, HasTraits):
     """FileChooser class."""
 
     _LBL_TEMPLATE = '<span style="color:{1};">{0}</span>'
     _LBL_NOFILE = 'No selection'
+
+    value = Unicode('', help="The selected path + filename")
 
     def __init__(
             self,
@@ -342,6 +345,7 @@ class FileChooser(VBox, ValueWidget):
 
         if ((self._selected_path is not None) and (self._selected_filename is not None)):
             selected = os.path.join(self._selected_path, self._selected_filename)
+            self.value = selected
             self._gb.layout.display = 'none'
             self._cancel.layout.display = 'none'
             self._select.description = self._change_desc
@@ -581,11 +585,6 @@ class FileChooser(VBox, ValueWidget):
         self.refresh()
 
     @property
-    def value(self) -> Optional[str]:
-        """Get selected value."""
-        return self.selected
-
-    @property
     def selected(self) -> Optional[str]:
         """Get selected value."""
         selected = None
@@ -637,4 +636,4 @@ class FileChooser(VBox, ValueWidget):
 
     def get_interact_value(self) -> Optional[str]:
         """Return the value which should be passed to interactive functions."""
-        return self.selected
+        return self.value


### PR DESCRIPTION
1) Allow the select_default property to be assigned in a 2 steps process:
    fc=FileChooser(path="...", filename="...")
    fc.select_default=True
So far, that was not possible (no err message, but no update of the property).

2) Fix the interaction, by allowing the observe method on "value".
Sample code (jupyter) showing the change of behaviour:

```
from ipyfilechooser import FileChooser
import ipywidgets as widgets
from ipywidgets import interact

fc = FileChooser('/home')

def f(x):
    return x

interact(f, x=fc)
```
